### PR TITLE
Update rounds from admin

### DIFF
--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -21,17 +21,17 @@ class Round < ApplicationRecord
         kata = JSON.parse(RestClient.get(url).body)["data"].find{|kata| kata["id"] == self.exercice.url}
         if kata && DateTime.parse(kata["completedAt"]).to_date == DateTime.now.to_date
           user.games.create(
-            round: self, 
+            round: self,
             finished_at: DateTime.parse(kata["completedAt"]),
             rating: 10
           )
         elsif attrs[:finish]
           user.games.create(
-            round: self, 
+            round: self,
             finished_at: DateTime.now,
             rating: 0
           )
-        end 
+        end
       rescue
       end
     end
@@ -41,6 +41,10 @@ class Round < ApplicationRecord
          .each_with_index do |game, index|
             game.update(rating: (10 - index > 0) ? (10 - index) : 0)
           end
+  end
+
+  def can_be_revealed?
+    pending? && (rank == 1 || city_quarter.rounds.where(role: role).find_by(rank: rank - 1, progress: :pasted))
   end
 
 end

--- a/app/views/rounds/_round.html.erb
+++ b/app/views/rounds/_round.html.erb
@@ -1,7 +1,7 @@
 <div class="col-md-2">
   <h3 class= "text-center">Round <%= round.rank %></h3>
 
-  <% if round.pending? && (round.rank == 1 || round.city_quarter.rounds.where(role: round.role).find_by(rank: round.rank - 1, progress: :pasted)) %>
+  <% if round.can_be_revealed? %>
     <div>Pending</div>
     <br>
     <%= link_to("Reveal", round_path(round), data: {turbo_method: :patch}, class: "btn btn-warning text-white") if current_user.admin %>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,3 +1,5 @@
+require Rails.root.join('lib/rails_admin/actions/update_round_status.rb')
+
 RailsAdmin.config do |config|
   config.asset_source = :sprockets
 
@@ -47,9 +49,34 @@ RailsAdmin.config do |config|
     edit
     delete
     show_in_app
+    update_round_status
 
-    ## With an audit adapter, you can add:
-    # history_index
-    # history_show
+    # member :update_round_status do
+    #   only ["Round"]
+    #   link_icon "fas fa-wrench"
+
+    #   controller do
+    #     Proc.new do
+    #       @round = Round.find(params[:id])
+
+    #       if @round.active?
+    #         @round.create_last_games(finish: true)
+    #         @round.pasted!
+    #       elsif @round.pending?
+    #         @round.active!
+    #       end
+
+    #       redirect_to rails_admin.edit_path(model_name: "Round", id: @round.id)
+    #     end
+    #   end
+
+    #   visible do
+    #     bindings[:object].can_be_revealed? || bindings[:object].active?
+    #   end
+
+    #   register_instance_option :show_in_navigation do
+    #       false
+    #     end
+    # end
   end
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -50,33 +50,5 @@ RailsAdmin.config do |config|
     delete
     show_in_app
     update_round_status
-
-    # member :update_round_status do
-    #   only ["Round"]
-    #   link_icon "fas fa-wrench"
-
-    #   controller do
-    #     Proc.new do
-    #       @round = Round.find(params[:id])
-
-    #       if @round.active?
-    #         @round.create_last_games(finish: true)
-    #         @round.pasted!
-    #       elsif @round.pending?
-    #         @round.active!
-    #       end
-
-    #       redirect_to rails_admin.edit_path(model_name: "Round", id: @round.id)
-    #     end
-    #   end
-
-    #   visible do
-    #     bindings[:object].can_be_revealed? || bindings[:object].active?
-    #   end
-
-    #   register_instance_option :show_in_navigation do
-    #       false
-    #     end
-    # end
   end
 end

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -1,0 +1,5 @@
+en:
+  admin:
+    actions:
+      update_round_status:
+        menu: Update Round Status

--- a/lib/rails_admin/actions/update_round_status.rb
+++ b/lib/rails_admin/actions/update_round_status.rb
@@ -1,0 +1,49 @@
+require 'rails_admin/config/actions'
+require 'rails_admin/config/actions/base'
+
+module RailsAdmin
+  module Config
+    module Actions
+      class UpdateRoundStatus < RailsAdmin::Config::Actions::Base
+        RailsAdmin::Config::Actions.register(self)
+
+        register_instance_option :member do
+          true
+        end
+
+        register_instance_option :only do
+          ['Round']
+        end
+
+        register_instance_option :link_icon do
+          'fas fa-wrench'
+        end
+
+        register_instance_option :visible? do
+          bindings[:object].can_be_revealed? || bindings[:object].active?
+        end
+
+        register_instance_option :show_in_navigation do
+          false
+        end
+
+        register_instance_option :controller do
+          Proc.new do
+            @round = Round.find(params[:id])
+
+            if @round.active?
+              @round.create_last_games(finish: true)
+              @round.pasted!
+              flash[:notice] = "Results are on the way !"
+            elsif @round.pending?
+              @round.active!
+              flash[:notice] = "Round is active !"
+            end
+
+            redirect_to rails_admin.edit_path(model_name: "Round", id: @round.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_admin/actions/update_round_status.rb
+++ b/lib/rails_admin/actions/update_round_status.rb
@@ -23,10 +23,6 @@ module RailsAdmin
           bindings[:object].can_be_revealed? || bindings[:object].active?
         end
 
-        register_instance_option :show_in_navigation do
-          false
-        end
-
         register_instance_option :controller do
           Proc.new do
             @round = Round.find(params[:id])


### PR DESCRIPTION
Cette PR a pour but de régler le problème ou il était nécessaire d'être connecté à un compte associé au round pour le `reveal` / `next`. Ce qui poussait la création de multiple comptes (1 par `city_quarter`)

- [x] Ajout d'une nouvelle action dans Rails admin pour mettre à jour les rounds (afficher le round et passer au suivant) 